### PR TITLE
Provide a label for chevron button

### DIFF
--- a/src/components/GoToButton.vue
+++ b/src/components/GoToButton.vue
@@ -13,8 +13,9 @@
       class="btn btn-sm btn-secondary dropdown-toggle" 
       data-bs-toggle="dropdown"
       :disabled="isGotoDisabled"
+      aria-label="Open options"
       aria-expanded="false">
-      <i class="mdi mdi-chevron-up"></i>
+      <i class="mdi mdi-chevron-up" aria-hidden="true"></i>
     </button>
     <ul class="dropdown-menu">
       <li 


### PR DESCRIPTION
Just downloaded this morning thanks to @csev. Here is a simple first PR around accessible text for a button:

```
<button type="button" data-bs-toggle="dropdown" aria-expanded="false" class="btn btn-sm btn-secondary dropdown-toggle"><i class="mdi mdi-chevron-up"></i></button>
```